### PR TITLE
Update to Jessie so we can use upx 3.91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER David Martin "dmartinpro@gmail.com"
 
 RUN apt-get update && apt-get -y install \


### PR DESCRIPTION
It will let us use upx 3.91 from trusted sources instead of using SourceForge.
